### PR TITLE
Add headers handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Do you have other Github actions (Lighthouse, Cypress, etc) that depend on the N
 
 **Required** The name of the Netlify site to reach `https://{site_name}.netlify.app`
 
+### `request_headers`
+
+Optional — Stringified HTTP Header object key/value pairs to send in requests (eg. `'{ "Authorization": "Basic YWxhZGRpbjpvcGVuc2VzYW1l }'`)
+
 ### `max_timeout`
 
 Optional — The amount of time to spend waiting on Netlify. Defaults to `60` seconds

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   site_name:
     description: "The Netlify site name to test against"
     required: true
+  request_headers:
+    description: "Stringified HTTP Header object key/value pairs to send in requests"
+    required: false
   max_timeout:
     description: "The max time to run the action"
     required: false

--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ const core = require("@actions/core");
 const github = require("@actions/github");
 const axios = require("axios");
 
-const waitForUrl = async (url, MAX_TIMEOUT) => {
+const waitForUrl = async (url, MAX_TIMEOUT, { headers }) => {
   const iterations = MAX_TIMEOUT / 2;
   for (let i = 0; i < iterations; i++) {
     try {
-      await axios.get(url);
+      await axios.get(url, { headers });
       return;
     } catch (e) {
       console.log("Url unavailable, retrying...");
@@ -31,8 +31,12 @@ const run = async () => {
     }
     const url = `https://deploy-preview-${PR_NUMBER}--${siteName}.netlify.app`;
     core.setOutput("url", url);
+    const extraHeaders = core.getInput("request_headers");
+    const headers = !extraHeaders ? {} : JSON.parse(extraHeaders)
     console.log(`Waiting for a 200 from: ${url}`);
-    await waitForUrl(url, MAX_TIMEOUT);
+    await waitForUrl(url, MAX_TIMEOUT, {
+      headers,
+    });
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
Hi Jake,

As discussed, here's a PR that addresses _Usage with a password protected Netlify website #4_.

To provide more flexibility, I added the possibility to add any kind of headers instead of just passing Authorization bearer.

That made sense to me but please let me know if you'd rather make it more explicit.