### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   url:
     description: "The fully qualified deploy preview URL"
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
[GitHub actions that run on Node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Updating to `node20` to address this deprecation.